### PR TITLE
removes about.js script tag from main layout

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -13,7 +13,6 @@
 	<script src="https://apis.google.com/js/platform.js" async defer></script>
 	<meta name="google-signin-client_id" content="361094340121-ikm4vh44nmp5lnibplt381nl6d2qqdml.apps.googleusercontent.com">
 	<script src="/assets/js/main.js"></script>
-	<script type="text/javascript" src="../models/about.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This was causing a GET and MIME type error; I removed the tag so that the source script is the corresponding main.js file